### PR TITLE
Fix misaligned and wide grid columns

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -29,7 +29,7 @@ Ventilator Challenge Questions
 
 {% block content %}
 <div class="govuk-grid-row">
-  <div class="">
+  <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
       Readiness to supply ventilators and ventilator components
@@ -39,7 +39,7 @@ Ventilator Challenge Questions
       supply of ventilators and ventilator components across the United Kingdom as part of the Government's response to
       COVID-19. These questions aim to identify the suitability and readiness of organisations to be involved in the
       initiative.
-      
+
     </p>
 
     <p>There are three main sections</p>
@@ -54,7 +54,7 @@ Ventilator Challenge Questions
     Screen reader support enabled.
   </p>
   </div>
-  <div>
+  <div class="govuk-grid-column-full">
     <form id="" action="submit" method="post" class="form">
 
 
@@ -82,14 +82,17 @@ Ventilator Challenge Questions
 
         <br />
         <br />
-
-        <p>By submitting this form, you agree to the information you share about your organisation being used by 
-          BEIS and any other Government departments and their delivery partners in relation to this initiative, 
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+        <p>By submitting this form, you agree to the information you share about your organisation being used by
+          BEIS and any other Government departments and their delivery partners in relation to this initiative,
           and to our <a href="privacy">privacy notice</a>.</p>
         <br />
         {{ govukButton({
             text: "Submit"
           }) }}
+          </div>
+        </div>
 
 
       </div>


### PR DESCRIPTION
This commit:
- makes the main column align with the template (problem was no item with a column class inside the `govuk-grid-row` container)
- restricts parts of the page that are just text to 2/3 width for a more readable line length*

before | after 
---|---
![image](https://user-images.githubusercontent.com/355079/76853733-c7107c80-6845-11ea-960d-31bf827176d0.png) | ![image](https://user-images.githubusercontent.com/355079/76853775-dabbe300-6845-11ea-9682-26f86f5c7efc.png)

***

* _Your main content should always be in a two-thirds column even if you’re not using a corresponding one-third column for secondary content._
https://design-system.service.gov.uk/styles/layout/#grid-system